### PR TITLE
Fixed compilation with MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,8 +147,12 @@ endif()
 # Add all necessary compiler warnings for debugging.       #
 #----------------------------------------------------------#
 if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
-  set(CMAKE_C_FLAGS    "${CMAKE_C_FLAGS} -Wall -Wextra")
-  set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+  set(BWC_DEBUG_FLAGS "-Wall")
+  if(NOT MSVC)
+    set(BWC_DEBUG_FLAGS "${BWC_DEBUG_FLAGS} -Wall -Wextra")
+  endif()
+  set(CMAKE_C_FLAGS    "${CMAKE_C_FLAGS} ${BWC_DEBUG_FLAGS}")
+  set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} ${BWC_DEBUG_FLAGS}")
 endif()
 
 #----------------------------------------------------------#

--- a/public_header.py
+++ b/public_header.py
@@ -182,7 +182,7 @@ else:
   file = "prim_types_double.h"
 
 print_flag = False
-with open(source.joinpath(file)) as f:
+with open(source.joinpath(file), encoding='utf-8') as f:
   for line in f:
     if("/*" in line and print_flag == 1):
       break
@@ -204,7 +204,7 @@ public_header.write(ubox + tab + sbox + lspaces * " " + "_  _ ____ ____ ____ ___
                            tab + sbox + lspaces * " " + "|  | |  | |___ |  \ |__| ___]" + rspaces * " " + "||\n" + 
                            tab + sbox + (text_width - 2*len(sbox) - len(tab)) * " " + "||\n" + lbox)
 
-with open(source.joinpath(file)) as f:
+with open(source.joinpath(file), encoding='utf-8') as f:
   for line in f:
     if("#define" in line):
       if("MAXIMUM_NO_PASSES" in line or
@@ -220,7 +220,7 @@ buff        = ""
 brktCnt     = 0
 
 for file in include_files:
-  with open(source.joinpath(file)) as f:
+  with open(source.joinpath(file), encoding='utf-8') as f:
     for line in f:
       if("BWC_" in line):
         if("ifndef" in line):
@@ -257,7 +257,7 @@ delimFlg    = False
 buff        = ""
 
 for file in include_files:
-  with open(source.joinpath(file)) as f:
+  with open(source.joinpath(file), encoding='utf-8') as f:
     for line in f:
       if("typedef enum" in line):
         while True:
@@ -295,7 +295,7 @@ buff        = ""
 brktCnt     = 0
 
 for file in include_files:
-  with open(source.joinpath(file)) as f:
+  with open(source.joinpath(file), encoding='utf-8') as f:
     for line in f:
       if("typedef struct" in line or
          "typedef union"  in line):
@@ -347,7 +347,7 @@ tmp      = ""
 buff     = ""
 
 for file in files:
-  with open(source.joinpath(file)) as f:
+  with open(source.joinpath(file), encoding='utf-8') as f:
     for line in f:
       if("#if defined" in line):
         line = next(f)

--- a/src/library/CMakeLists.txt
+++ b/src/library/CMakeLists.txt
@@ -110,8 +110,12 @@ target_include_directories(bwclib PRIVATE ${CMAKE_SOURCE_DIR}/include/library/pr
 
 #----------------------------------------------------------#
 # Link the BigWhoop library to the math.h library.         #
+# With MSVC Math functions are built into the C runtime,   #
+# no separate linking needed                               #
 #----------------------------------------------------------#
-target_link_libraries(bwclib PRIVATE m)
+if(NOT MSVC)
+  target_link_libraries(bwclib PRIVATE m)
+endif()
 
 #----------------------------------------------------------#
 # Setup the install directories and target exporting for   #

--- a/src/library/libbwc.c
+++ b/src/library/libbwc.c
@@ -3023,8 +3023,12 @@ bwc_create_compression(bwc_codec *codec, bwc_stream *stream, char *rate_control)
    }
    else
    {
+      // Platform-specific strtok implementation
+      #ifdef _MSC_VER
+         #define strtok_r strtok_s
+      #endif
       token = strtok_r(rate_control, "-, ", &ptr);
-
+      // Unix/Linux systems already have strtok_r
       if(token)
       {
          for(control->nLayers = 0; token; token = strtok_r(NULL, "-, ", &ptr))

--- a/src/tools/bwccmdl.c
+++ b/src/tools/bwccmdl.c
@@ -848,7 +848,10 @@ parse_opt(int                key,
             {
               argp_error(state, "The wavelet kernels can only be defined once.\n");
             }
-
+          // Platform-specific strtok implementation
+          #ifdef _MSC_VER
+            #define strtok_r strtok_s
+          #endif
           for(token =  strtok_r(arg, ",", &ptr), i = 0;
               token != NULL && i < 4;
               token = strtok_r(NULL, ",", &ptr), i++)

--- a/tests/test_bitstream.cpp
+++ b/tests/test_bitstream.cpp
@@ -57,7 +57,7 @@
 #endif
 
 TEST_CASE( "Bit stream initialization", "[init_bitstream]" ) {
-    uint32 size = 4;
+    constexpr uint32 size = 4;
     uchar inp_mem[size];
     uchar out_mem[size];
     out_mem[3] = inp_mem[0] = 1;

--- a/tests/test_libbwc.cpp
+++ b/tests/test_libbwc.cpp
@@ -56,7 +56,7 @@
 #endif
 
 TEST_CASE( "Stream initialization", "[bwc_init_stream]" ) {
-    uint32 size = 4;
+    constexpr uint32 size = 4;
     uchar inp_mem[size];
     uchar out_mem[size];
     out_mem[3] = inp_mem[0] = 1;


### PR DESCRIPTION
Symbol export is still not fixed, for now
   set_target_properties(bwclib PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
in consuming project just exports everything. 