### PR TITLE
fix avoid increment size 0

### DIFF
--- a/src/library/bitstream.c
+++ b/src/library/bitstream.c
@@ -174,7 +174,7 @@ init_bitstream(uchar* memory, uint32 size, char instr)
   stream->memory    = memory;
   stream->t         = (instr == 'c') ? 8 : 0;
   stream->Lmax      = size;
-  stream->size_incr = (uint64)(size / 2);
+  stream->size_incr = (uint64)((size / 2) ?: 1);
 
   /*--------------------------------------------------------*\
   ! Return the stream memory handle.                         !


### PR DESCRIPTION
If the initial buffer size for a bitstream is 1, the increment size is initialized to 0, and breaks dynamic reallocations in emit_bit.