### PR TITLE
Tests for emit_bit

### DIFF
--- a/tests/test_bitstream.cpp
+++ b/tests/test_bitstream.cpp
@@ -47,6 +47,9 @@
 
 #include <cstdint>
 
+#include <iostream>
+#include <bitset>
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -229,4 +232,63 @@ TEST_CASE ("Pass symbol to bitstream", "[emit_symbol]")
   REQUIRE (stream->Lmax == 0);
 
   free (stream);
+}
+
+TEST_CASE ("Test emitting alternating bits", "[emit_bit]")
+{
+  uint32     size               = 1;
+  uchar     *inp_mem            = (uchar*)calloc(size, sizeof(uchar));
+  uchar      byte               = 0x00;
+  char       instr              = 'c';
+  bitstream *stream;
+
+  stream = init_bitstream (inp_mem, size, instr);
+  uint64 org_Lmax = stream->Lmax;
+
+  // 0b01010101
+  // Emitting 8 bits
+  for (int i = 4; i >= 1; --i)
+  {
+    emit_bit(stream, 0);
+    emit_bit(stream, 1);
+    byte |= (1 << 2*i-2);
+    REQUIRE ((stream && !stream->error));
+    if (i != 1 && i != 4) 
+    {
+      REQUIRE (stream->t == 2*i-2); // expected bit position
+      REQUIRE (stream->T == byte); // expected state of T
+    }
+    else if (i == 1)
+    {
+      REQUIRE (stream->t == 8);            // reset bit position
+      REQUIRE (stream->T == 0x00);         // reset T buffer
+      REQUIRE (stream->memory[0] == byte); // filled buffer was transferred
+      REQUIRE (stream->L == 1);            // updated used bytes
+    }
+  }
+  REQUIRE(stream->Lmax == org_Lmax);
+
+  // 0b10101010
+  // Emitting 8 bits
+  byte = 0x00;
+  for (int i = 4; i >= 1; --i)
+  {
+    emit_bit(stream, 1);
+    emit_bit(stream, 0);
+    byte |= (1 << 2*i-1);
+    REQUIRE ((stream && !stream->error));
+    if (i != 1 && i != 4)
+    {
+      REQUIRE (stream->t == 2*i-2); // current bit position
+      REQUIRE (stream->T == byte);  // state of T
+    }
+    else if (i == 1)
+    {
+      REQUIRE (stream->t == 8);            // reset bit position
+      REQUIRE (stream->T == 0x00);         // reset T buffer
+      REQUIRE (stream->memory[1] == byte); // filled buffer was transferred
+      REQUIRE (stream->L == 2);            // updated used bytes
+      REQUIRE(stream->Lmax != org_Lmax);   // updated memory size
+    }
+  }
 }


### PR DESCRIPTION
Added test for emit_bit. Split it into two scenarios.

1) The simple case in which all 8 bits of the buffer byte can be used.
2) The case in which the codestream markers are avoided, i.e., ranging FFFF to FF80 bit sequences.

These tests identify a bug in the initialization of bitstream #17. So #17 needs to be in main for these tests not to fail.

 Please review: 
- Are all possible scenarios covered?
- Are all the `REQUIRE` asserts set to cover respective state/variable changes?
- Don't bother about formatting since this is a PR for #11.
