### PR TITLE
do not include from Catch2 source directory

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,9 +42,7 @@
 #|                                                                                                |#
 #*================================================================================================*#
 
-list(APPEND CMAKE_MODULE_PATH ${Catch2_SOURCE_DIR}/extras)
 include(CTest)
-include(Catch)
 
 function(bigwhoop_unit_test TESTCASE)
   add_executable(${TESTCASE} "${TESTCASE}.cpp")


### PR DESCRIPTION
This does not seem to be required and only works when building Catch2 from source. Thus, it is not compatible with setting
FETCHCONTENT_TRY_FIND_PACKAGE_MODE=ALWAYS, which uses an installed Catch2 package instead of building it in-tree. However, this mode is encouraged when building with the Homebrew (brew.sh) package manager.

Otherwise, providing an additional flag (HOMEBREW_ALLOW_FETCHCONTENT=ON) avoiding this check is necessary and building the vistle package from https://github.com/hlrs-vis/homebrew-tap breaks.